### PR TITLE
Remove invalid dash-separated key 'description-file' & PYPI releases & release 0.3.0

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,32 @@
+name: Upload release to PyPI (Test & Live)
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI (Test & Live)
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/json-merge-patch
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - run: pip install --upgrade build
+    - run: python -m build --sdist --wheel
+    - name: Publish package distributions to TEST PyPI
+      if: github.event_name == 'push'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
+    - name: Publish package distributions to LIVE PyPI
+      if:  github.event_name == 'release'
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+
+Remove invalid dash-separated key 'description-file' in our packaging info https://github.com/OpenDataServices/json-merge-patch/pull/9
+
 ## Changed
 
 Python support is now 3.9+ only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-03-25
+
 ## Fixed
 
 Remove invalid dash-separated key 'description-file' in our packaging info https://github.com/OpenDataServices/json-merge-patch/pull/9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,1 @@
-[metadata]
-description-file = README.md
+

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 setup(name='json-merge-patch',
-      version='0.2',
+      version='0.3.0',
       description='JSON Merge Patch library (https://tools.ietf.org/html/rfc7386)',
       author='Open Data Services',
       author_email='code@opendataservices.coop',


### PR DESCRIPTION
As far as I can tell, the key isn't an officially supported key and doesn't actually do anything

https://github.com/OpenDataServices/json-merge-patch/pull/9